### PR TITLE
Allow overwriting wordpress-core type packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
 	"conflict": {
 		"composer/installers": "<1.0.6"
 	},
+	"replace": {
+ 		"johnpbloch/wordpress-core-installer":"*"
+	},
 	"scripts": {
 		"test:phpunit": "phpunit",
 		"test": [

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,17 @@
 		}
 	],
 	"autoload": {
-		"psr-0": {
-			"johnpbloch\\Composer\\": "src/"
+		"psr-4": {
+			"Roots\\Composer\\": "src/"
 		}
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"Tests\\JohnPBloch\\Composer\\": "tests/"
+			"Tests\\Roots\\Composer\\": "tests/"
 		}
 	},
 	"extra": {
-		"class": "johnpbloch\\Composer\\WordPressCorePlugin"
+		"class": "Roots\\Composer\\WordPressCorePlugin"
 	},
 	"require": {
 		"composer-plugin-api": "^1.0"

--- a/src/WordPressCoreInstaller.php
+++ b/src/WordPressCoreInstaller.php
@@ -19,7 +19,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace johnpbloch\Composer;
+namespace Roots\Composer;
 
 use Composer\Config;
 use Composer\Installer\LibraryInstaller;

--- a/src/WordPressCorePlugin.php
+++ b/src/WordPressCorePlugin.php
@@ -19,7 +19,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace johnpbloch\Composer;
+namespace Roots\Composer;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;

--- a/src/johnpbloch/Composer/WordPressCoreInstaller.php
+++ b/src/johnpbloch/Composer/WordPressCoreInstaller.php
@@ -67,7 +67,8 @@ class WordPressCoreInstaller extends LibraryInstaller {
 		}
 		if (
 			! empty( self::$_installedPaths[ $installationDir ] ) &&
-			$prettyName !== self::$_installedPaths[ $installationDir ]
+			$prettyName !== self::$_installedPaths[ $installationDir ] &&
+			$package->getType() !== self::TYPE
 		) {
 			$conflict_message = $this->getConflictMessage( $prettyName, self::$_installedPaths[ $installationDir ] );
 			throw new \InvalidArgumentException( $conflict_message );

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -19,14 +19,14 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace Tests\JohnPBloch\Composer\phpunit;
+namespace Tests\Roots\Composer\phpunit;
 
 use Composer\Composer;
 use Composer\Config;
 use Composer\IO\NullIO;
 use Composer\Package\Package;
 use Composer\Package\RootPackage;
-use johnpbloch\Composer\WordPressCoreInstaller;
+use Roots\Composer\WordPressCoreInstaller;
 use PHPUnit\Framework\TestCase;
 
 class WordPressCoreInstallerTest extends TestCase {
@@ -172,7 +172,7 @@ class WordPressCoreInstallerTest extends TestCase {
 	}
 
 	private function resetInstallPaths() {
-		$prop = new \ReflectionProperty( '\johnpbloch\Composer\WordPressCoreInstaller', '_installedPaths' );
+		$prop = new \ReflectionProperty( '\Roots\Composer\WordPressCoreInstaller', '_installedPaths' );
 		$prop->setAccessible( true );
 		$prop->setValue( array() );
 	}

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -136,6 +136,20 @@ class WordPressCoreInstallerTest extends TestCase {
 		$installer->getInstallPath( $package1 );
 		$installer->getInstallPath( $package2 );
 	}
+	
+	public function testTwoPackagesCannotShareDirectoryUnlessWpCoreType() {
+		$composer  = $this->createComposer();
+		$installer = new WordPressCoreInstaller( new NullIO(), $composer );
+		$package1  = new Package( 'johnpbloch/wordpress', '4.9.8', '4.9.8' );
+		$package1->setType('wordpress-core');
+		$package2  = new Package( 'roots/wordpress', '5.0', '5.0' );
+		$package2->setType('wordpress-core');
+		
+		$installer->getInstallPath( $package1 );
+		$installer->getInstallPath( $package2 );
+		
+		$this->assertTrue(true); // no exceptions thrown
+	}
 
 	/**
 	 * @dataProvider                   dataProviderSensitiveDirectories

--- a/tests/phpunit/WordPressCorePluginTest.php
+++ b/tests/phpunit/WordPressCorePluginTest.php
@@ -19,13 +19,13 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace Tests\JohnPBloch\Composer\phpunit;
+namespace Tests\Roots\Composer\phpunit;
 
 use Composer\Composer;
 use Composer\Config;
 use Composer\Installer\InstallationManager;
 use Composer\IO\NullIO;
-use johnpbloch\Composer\WordPressCorePlugin;
+use Roots\Composer\WordPressCorePlugin;
 use PHPUnit\Framework\TestCase;
 
 class WordPressCorePluginTest extends TestCase {
@@ -41,7 +41,7 @@ class WordPressCorePluginTest extends TestCase {
 
 		$installer = $installationManager->getInstaller( 'wordpress-core' );
 
-		$this->assertInstanceOf( '\johnpbloch\Composer\WordPressCoreInstaller', $installer );
+		$this->assertInstanceOf( '\Roots\Composer\WordPressCoreInstaller', $installer );
 	}
 
 }


### PR DESCRIPTION
prevent issues like https://discourse.roots.io/t/johnpbloch-wordpress-moved-to-a-new-configuration-and-wp-goes-missing/9124/45