### PR TITLE
Allow composer v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 phpunit.xml
 clover.xml
 .phpunit.result.cache
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 vendor
 phpunit.xml
 clover.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
   - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
 before_script:
   - composer update
 script: composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: php
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
 php:
-  - '5.4'
-  - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
 before_script:
   - composer update
 script: composer test

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information on this site setup and using Composer to manage a whole Wor
 ### Usage
 To set up a custom WordPress build package to use this as a custom installer, add the following to your package's composer file:
 
-```
+```json
 "type": "wordpress-core",
 "require": {
 	"johnpbloch/wordpress-core-installer": "^1.0"
@@ -24,7 +24,7 @@ To set up a custom WordPress build package to use this as a custom installer, ad
 
 By default, this package will install a `wordpress-core` type package in the `wordpress` directory. To change this you can add the following to either your custom WordPress core type package or the root composer package:
 
-```
+```json
 "extra": {
 	"wordpress-install-dir": "custom/path"
 }
@@ -32,7 +32,7 @@ By default, this package will install a `wordpress-core` type package in the `wo
 
 The root composer package can also declare custom paths as an object keyed by package name:
 
-```
+```json
 "extra": {
 	"wordpress-install-dir": {
 		"wordpress/wordpress": "wordpress",

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ To set up a custom WordPress build package to use this as a custom installer, ad
 ```json
 "type": "wordpress-core",
 "require": {
-	"johnpbloch/wordpress-core-installer": "^1.0"
+	"johnpbloch/wordpress-core-installer": "^2.0"
 }
 ```
+
+If you need to maintain support for PHP versions lower than 5.6 (not recommended!), use `^1.0` as your version constraint in the above.
 
 By default, this package will install a `wordpress-core` type package in the `wordpress` directory. To change this you can add the following to either your custom WordPress core type package or the root composer package:
 
@@ -43,3 +45,16 @@ The root composer package can also declare custom paths as an object keyed by pa
 
 ### License
 This is licensed under the GPL version 2 or later.
+
+### Changelog
+
+##### 2.0.0
+- Added support for Composer v2. Special thanks to @Ayesh for the original pull request to add this support.
+- Bumped minimum required PHP version to 5.6 (same as WP). If you need to stick with an older PHP version, you're probably ok with also sticking with an older version of Composer and can continue to use `^1.0` as your version constraint.
+- Other various fixes and improvements to README, tests, etc.
+
+##### 1.0.0
+- Initial stable release
+- Added tests and CI
+- Support added for custom vendor directories
+- Added sanity check for overwriting sensitive directories

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
 		"class": "johnpbloch\\Composer\\WordPressCorePlugin"
 	},
 	"require": {
-		"composer-plugin-api": "^1.0",
+		"composer-plugin-api": "^1.0 || ^2.0",
 		"php": ">=5.6.0"
 	},
 	"require-dev": {
-		"composer/composer": "^1.0",
+		"composer/composer": "^1.0 || ^2.0",
 		"phpunit/phpunit": ">=5.7.27"
 	},
 	"conflict": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
 		"class": "johnpbloch\\Composer\\WordPressCorePlugin"
 	},
 	"require": {
-		"composer-plugin-api": "^1.0"
+		"composer-plugin-api": "^1.0",
+		"php": ">=5.6.0"
 	},
 	"require-dev": {
 		"composer/composer": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	},
 	"require-dev": {
 		"composer/composer": "^1.0",
-		"phpunit/phpunit": ">=4.8.35"
+		"phpunit/phpunit": ">=5.7.27"
 	},
 	"conflict": {
 		"composer/installers": "<1.0.6"

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
 		"class": "johnpbloch\\Composer\\WordPressCorePlugin"
 	},
 	"require": {
-		"composer-plugin-api": "^1.0"
+		"composer-plugin-api": "^1.0 || ^2.0"
 	},
 	"require-dev": {
-		"composer/composer": "^1.0",
+		"composer/composer": "^1.0 || ^2.0",
 		"phpunit/phpunit": ">=4.8.35"
 	},
 	"conflict": {

--- a/src/johnpbloch/Composer/WordPressCorePlugin.php
+++ b/src/johnpbloch/Composer/WordPressCorePlugin.php
@@ -38,4 +38,16 @@ class WordPressCorePlugin implements PluginInterface {
 		$composer->getInstallationManager()->addInstaller( $installer );
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	public function deactivate( Composer $composer, IOInterface $io ) {
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function uninstall( Composer $composer, IOInterface $io ) {
+	}
+
 }

--- a/src/johnpbloch/Composer/WordPressCorePlugin.php
+++ b/src/johnpbloch/Composer/WordPressCorePlugin.php
@@ -38,4 +38,11 @@ class WordPressCorePlugin implements PluginInterface {
 		$composer->getInstallationManager()->addInstaller( $installer );
 	}
 
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -175,8 +175,15 @@ class WordPressCoreInstallerTest extends TestCase {
 	private function jpbExpectException( $class, $message = '', $isRegExp = false ) {
 		$this->expectException($class);
 		if ( $message ) {
-			$isRegExp || $this->expectExceptionMessage( $message );
-			$isRegExp && $this->expectExceptionMessageRegExp( $message );
+			if ( $isRegExp ) {
+				if ( method_exists( $this, 'expectExceptionMessageRegExp' ) ) {
+					$this->expectExceptionMessageRegExp( $message );
+				} else {
+					$this->expectExceptionMessageMatches( $message );
+				}
+			} else {
+				$this->expectExceptionMessage( $message );
+			}
 		}
 	}
 

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -128,7 +128,7 @@ class WordPressCoreInstallerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider                   dataProviderSensitiveDirectories
+	 * @dataProvider dataProviderSensitiveDirectories
 	 */
 	public function testSensitiveInstallDirectoriesNotAllowed( $directory ) {
 		$this->expectException( '\InvalidArgumentException' );

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -115,11 +115,9 @@ class WordPressCoreInstallerTest extends TestCase {
 		$this->assertEquals( 'wp', $installer->getInstallPath( $package ) );
 	}
 
-	/**
-	 * @expectedException \InvalidArgumentException
-	 * @expectedExceptionMessage Two packages (test/bazbat and test/foobar) cannot share the same directory!
-	 */
 	public function testTwoPackagesCannotShareDirectory() {
+		$this->expectException( '\InvalidArgumentException' );
+		$this->expectExceptionMessage( 'Two packages (test/bazbat and test/foobar) cannot share the same directory!' );
 		$composer  = $this->createComposer();
 		$installer = new WordPressCoreInstaller( new NullIO(), $composer );
 		$package1  = new Package( 'test/foobar', '1.1.1.1', '1.1.1.1' );
@@ -131,10 +129,10 @@ class WordPressCoreInstallerTest extends TestCase {
 
 	/**
 	 * @dataProvider                   dataProviderSensitiveDirectories
-	 * @expectedException \InvalidArgumentException
-	 * @expectedExceptionMessageRegExp /Warning! .+? is an invalid WordPress install directory \(from test\/package\)!/
 	 */
 	public function testSensitiveInstallDirectoriesNotAllowed( $directory ) {
+		$this->expectException( '\InvalidArgumentException' );
+		$this->expectExceptionMessageRegExp( '/Warning! .+? is an invalid WordPress install directory \(from test\/package\)!/' );
 		$composer  = $this->createComposer();
 		$installer = new WordPressCoreInstaller( new NullIO(), $composer );
 		$package   = new Package( 'test/package', '1.1.0.0', '1.1' );

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -116,8 +116,10 @@ class WordPressCoreInstallerTest extends TestCase {
 	}
 
 	public function testTwoPackagesCannotShareDirectory() {
-		$this->expectException( '\InvalidArgumentException' );
-		$this->expectExceptionMessage( 'Two packages (test/bazbat and test/foobar) cannot share the same directory!' );
+		$this->jpbExpectException(
+			'\InvalidArgumentException',
+			'Two packages (test/bazbat and test/foobar) cannot share the same directory!'
+		);
 		$composer  = $this->createComposer();
 		$installer = new WordPressCoreInstaller( new NullIO(), $composer );
 		$package1  = new Package( 'test/foobar', '1.1.1.1', '1.1.1.1' );
@@ -131,8 +133,11 @@ class WordPressCoreInstallerTest extends TestCase {
 	 * @dataProvider dataProviderSensitiveDirectories
 	 */
 	public function testSensitiveInstallDirectoriesNotAllowed( $directory ) {
-		$this->expectException( '\InvalidArgumentException' );
-		$this->expectExceptionMessageRegExp( '/Warning! .+? is an invalid WordPress install directory \(from test\/package\)!/' );
+		$this->jpbExpectException(
+			'\InvalidArgumentException',
+			'/Warning! .+? is an invalid WordPress install directory \(from test\/package\)!/',
+			true
+		);
 		$composer  = $this->createComposer();
 		$installer = new WordPressCoreInstaller( new NullIO(), $composer );
 		$package   = new Package( 'test/package', '1.1.0.0', '1.1' );
@@ -165,6 +170,19 @@ class WordPressCoreInstallerTest extends TestCase {
 		$composer->setConfig( new Config() );
 
 		return $composer;
+	}
+
+	private function jpbExpectException( $class, $message = '', $isRegExp = false ) {
+		if ( method_exists( $this, 'expectException' ) ) {
+			$this->expectException($class);
+			if ( $message ) {
+				$isRegExp || $this->expectExceptionMessage( $message );
+				$isRegExp && $this->expectExceptionMessageRegExp( $message );
+			}
+		} else {
+			$isRegExp || $this->setExpectedException( $class, $message );
+			$isRegExp && $this->setExpectedExceptionRegExp( $class, $message );
+		}
 	}
 
 }

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -173,15 +173,10 @@ class WordPressCoreInstallerTest extends TestCase {
 	}
 
 	private function jpbExpectException( $class, $message = '', $isRegExp = false ) {
-		if ( method_exists( $this, 'expectException' ) ) {
-			$this->expectException($class);
-			if ( $message ) {
-				$isRegExp || $this->expectExceptionMessage( $message );
-				$isRegExp && $this->expectExceptionMessageRegExp( $message );
-			}
-		} else {
-			$isRegExp || $this->setExpectedException( $class, $message );
-			$isRegExp && $this->setExpectedExceptionRegExp( $class, $message );
+		$this->expectException($class);
+		if ( $message ) {
+			$isRegExp || $this->expectExceptionMessage( $message );
+			$isRegExp && $this->expectExceptionMessageRegExp( $message );
 		}
 	}
 

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -148,7 +148,7 @@ class WordPressCoreInstallerTest extends TestCase {
 	}
 
 	/**
-	 * @beforeClass
+	 * @before
 	 * @afterClass
 	 */
 	public static function resetInstallPaths() {

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -31,14 +31,6 @@ use PHPUnit\Framework\TestCase;
 
 class WordPressCoreInstallerTest extends TestCase {
 
-	protected function setUp() {
-		$this->resetInstallPaths();
-	}
-
-	protected function tearDown() {
-		$this->resetInstallPaths();
-	}
-
 	public function testSupports() {
 		$installer = new WordPressCoreInstaller( new NullIO(), $this->createComposer() );
 
@@ -157,7 +149,11 @@ class WordPressCoreInstallerTest extends TestCase {
 		);
 	}
 
-	private function resetInstallPaths() {
+	/**
+	 * @beforeClass
+	 * @afterClass
+	 */
+	public static function resetInstallPaths() {
 		$prop = new \ReflectionProperty( '\johnpbloch\Composer\WordPressCoreInstaller', '_installedPaths' );
 		$prop->setAccessible( true );
 		$prop->setValue( array() );


### PR DESCRIPTION
### About
This pulls latest changes from upstream, which allows for Composer v2 compatibility given by the following PR https://github.com/johnpbloch/wordpress-core-installer/pull/27.

These changes should allow us to close https://github.com/roots/wordpress-core-installer/issues/2.

### Changes
When merging from upstream, conflicts arose as there were references to `johnpbloch`, which I've changed back to use `Roots`, in the following files:
- `README.md`
- `src/WordPressCoreInstallerTest.php`
- `src/WordPressCorePluginTest.php`

Also method signature for `WordPressCoreInstallerTest#resetInstallPaths()` has changed to being `static`.

### Testing notes
To change back and forth between composer v2 (snapshot) and stable v1, you can do as follows:
```bash
# Install v2 snapshot
composer self-update --snapshot

# Rollback to stable v1 release
composer self-update --rollback
```

### Backwards compatibility breaks
I would recommand we follow John's example, and tag this change as v2.0.0, as though the updates from upstream we're dropping support for `php5.4` and `php5.5` in favor of `php7.3` and `php7.4`. See changes in `.travis.yml`-file.