### PR TITLE
Do not mislead users with 2.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To set up a custom WordPress build package to use this as a custom installer, ad
 ```json
 "type": "wordpress-core",
 "require": {
-	"roots/wordpress-core-installer": "^2.0"
+	"roots/wordpress-core-installer": "^1.100"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,16 +46,3 @@ The root composer package can also declare custom paths as an object keyed by pa
 
 ### License
 This is licensed under the GPL version 2 or later.
-
-### Changelog
-
-##### 2.0.0
-- Added support for Composer v2. Special thanks to @Ayesh for the original pull request to add this support.
-- Bumped minimum required PHP version to 5.6 (same as WP). If you need to stick with an older PHP version, you're probably ok with also sticking with an older version of Composer and can continue to use `^1.0` as your version constraint.
-- Other various fixes and improvements to README, tests, etc.
-
-##### 1.0.0
-- Initial stable release
-- Added tests and CI
-- Support added for custom vendor directories
-- Added sanity check for overwriting sensitive directories


### PR DESCRIPTION
There is no such a tag: https://github.com/roots/wordpress-core-installer/tags