### PR TITLE
Drop Composer v1 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          tools: composer:v2
           coverage: xdebug
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
+          - '8.5'
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@
 [![Follow Roots](https://img.shields.io/badge/follow%20@rootswp-1da1f2?logo=twitter&logoColor=ffffff&message=&style=flat-square)](https://twitter.com/rootswp)
 [![Sponsor Roots](https://img.shields.io/badge/sponsor%20roots-525ddc?logo=github&style=flat-square&logoColor=ffffff&message=)](https://github.com/sponsors/roots)
 
-*This is a fork of [johnpbloch/wordpress-core-installer](https://github.com/johnpbloch/wordpress-core-installer) with some fixes to enhance compatibility with [roots/wordpress](https://packagist.org/packages/roots/wordpress)*
+> [!NOTE]
+> This is a fork of [johnpbloch/wordpress-core-installer](https://github.com/johnpbloch/wordpress-core-installer) with fixes to enhance compatibility with [roots/wordpress](https://packagist.org/packages/roots/wordpress).
 
 A custom Composer plugin to install WordPress core outside of `vendor`.
 
 This installer is meant to support a rather specific WordPress installation setup in which WordPress is installed in a subdirectory ([see the WordPress codex on that subject](https://codex.wordpress.org/Giving_WordPress_Its_Own_Directory)) and in which the location of `WP_CONTENT_DIR` and `WP_CONTENT_URL` have been customized to be outside of WordPress core ([see the WordPress codex on that subject](https://codex.wordpress.org/Editing_wp-config.php#Moving_wp-content_folder)). This is because composer will delete your whole wp-content directory every time it updates core if you don't separate the two. If that installation setup isn't what you are looking for, then this installer is probably not something you will want to use.
 
-For more information on this site setup and using Composer to manage a whole WordPress site, [check out @Rarst's informational website](https://composer.rarst.net/) which also includes [a site stack example using this package](https://composer.rarst.net/recipe/site-stack/).
+For more information on using Composer with WordPress, check out our [Composer WordPress resources](https://roots.io/composer-wordpress-resources/). Use [WP Packages](https://wp-packages.org/) to install WordPress plugins and themes via Composer, and see the [`roots/wordpress` documentation](https://wp-packages.org/roots-wordpress) for WordPress core installation options.
+
+## Support us
+
+Roots is an independent open source org, supported only by developers like you. Your sponsorship funds [WP Packages](https://wp-packages.org/) and the entire Roots ecosystem, and keeps them independent. Support us by purchasing [Radicle](https://roots.io/radicle/) or [sponsoring us on GitHub](https://github.com/sponsors/roots) — sponsors get access to our private Discord.
 
 ## Requirements
 
@@ -24,10 +29,6 @@ Composer 2 requires explicitly allowing plugins. If needed, run:
 ```bash
 composer config --no-plugins allow-plugins.roots/wordpress-core-installer true
 ```
-
-## Support us
-
-Roots is an independent open source org, supported only by developers like you. Your sponsorship funds [WP Packages](https://wp-packages.org/) and the entire Roots ecosystem, and keeps them independent. Support us by purchasing [Radicle](https://roots.io/radicle/) or [sponsoring us on GitHub](https://github.com/sponsors/roots) — sponsors get access to our private Discord.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ This installer is meant to support a rather specific WordPress installation setu
 
 For more information on this site setup and using Composer to manage a whole WordPress site, [check out @Rarst's informational website](https://composer.rarst.net/) which also includes [a site stack example using this package](https://composer.rarst.net/recipe/site-stack/).
 
+## Requirements
+
+- Composer 2+
+- PHP 7.2.24+
+
+Composer 2 requires explicitly allowing plugins. If needed, run:
+
+```bash
+composer config --no-plugins allow-plugins.roots/wordpress-core-installer true
+```
+
 ## Support us
 
 Roots is an independent open source org, supported only by developers like you. Your sponsorship funds [WP Packages](https://wp-packages.org/) and the entire Roots ecosystem, and keeps them independent. Support us by purchasing [Radicle](https://roots.io/radicle/) or [sponsoring us on GitHub](https://github.com/sponsors/roots) — sponsors get access to our private Discord.

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,11 @@
 		"class": "Roots\\Composer\\WordPressCorePlugin"
 	},
 	"require": {
-		"composer-plugin-api": "^1.0 || ^2.0",
+		"composer-plugin-api": "^2.0",
 		"php": ">=7.2.24"
 	},
 	"require-dev": {
-		"composer/composer": "^1.0 || ^2.0",
+		"composer/composer": "^2.0",
 		"phpunit/phpunit": "^8.5"
 	},
 	"conflict": {

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -221,11 +221,7 @@ class WordPressCoreInstallerTest extends TestCase
         $this->expectException($class);
         if ($message) {
             if ($isRegExp) {
-                if (method_exists($this, 'expectExceptionMessageRegExp')) {
-                    $this->expectExceptionMessageRegExp($message);
-                } else {
-                    $this->expectExceptionMessageMatches($message);
-                }
+                $this->expectExceptionMessageMatches($message);
             } else {
                 $this->expectExceptionMessage($message);
             }

--- a/tests/phpunit/WordPressCorePluginTest.php
+++ b/tests/phpunit/WordPressCorePluginTest.php
@@ -24,11 +24,8 @@ namespace Tests\Roots\Composer\phpunit;
 use Composer\Composer;
 use Composer\Config;
 use Composer\Installer\InstallationManager;
-use Composer\IO\IOInterface;
 use Composer\IO\NullIO;
 use Composer\Package\RootPackage;
-use Composer\Plugin\PluginInterface;
-use Composer\Test\Mock\HttpDownloaderMock;
 use Composer\Util\HttpDownloader;
 use Composer\Util\Loop;
 use Roots\Composer\WordPressCorePlugin;
@@ -55,7 +52,9 @@ class WordPressCorePluginTest extends TestCase
         $composer->setDownloadManager($downloadManager);
         
         $nullIO = new NullIO();
-        $installationManager = $this->getInstallationManager($composer, $nullIO);
+        $http = new HttpDownloader($nullIO, $composer->getConfig());
+        $loop = new Loop($http);
+        $installationManager = new InstallationManager($loop, $nullIO);
         $composer->setInstallationManager($installationManager);
 
         $plugin = new WordPressCorePlugin();
@@ -64,29 +63,5 @@ class WordPressCorePluginTest extends TestCase
         $installer = $installationManager->getInstaller('wordpress-core');
 
         $this->assertInstanceOf('\Roots\Composer\WordPressCoreInstaller', $installer);
-    }
-
-    /**
-     * @param Composer $composer
-     * @param IOInterface $io
-     *
-     * @return InstallationManager
-     */
-    private function getInstallationManager($composer, $io)
-    {
-        $installationManager = null;
-        switch (explode('.', PluginInterface::PLUGIN_API_VERSION)[0]) {
-            case '1':
-                $installationManager = new InstallationManager();
-                break;
-            case '2':
-            default:
-                $http                = new HttpDownloader($io, $composer->getConfig());
-                $loop                = new Loop($http);
-                $installationManager = new InstallationManager($loop, $io);
-                break;
-        }
-
-        return $installationManager;
     }
 }


### PR DESCRIPTION
Composer v1 has been EOL since October 2022.

- Drop Composer v1 support (`composer-plugin-api` and `composer/composer` constraints updated to `^2.0`)
- Remove v1/v2 version-switching logic in `WordPressCorePluginTest`
- Fix PHPUnit deprecation warning by replacing `expectExceptionMessageRegExp` with `expectExceptionMessageMatches`
- Pin CI to Composer v2
- Add Requirements section to README